### PR TITLE
Remove one layer of closures

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 [![Aqua QA](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 
-Automatic differentiation of implicit functions.
+Automatic differentiation of functions $\hat{y}(x)$ defined implicitly by a condition $F(x, \hat{y}(x)) = 0$.
 
 If you just need a quick introduction, check out our [JuliaCon 2022 talk](https://youtu.be/TkVDcujVNJ4) and the associated [Pluto notebook](https://gdalle.github.io/ImplicitDifferentiation-JuliaCon2022/).
 If you plan to use our package, see the [documentation](https://gdalle.github.io/ImplicitDifferentiation.jl/dev) for details.

--- a/src/ImplicitDifferentiation.jl
+++ b/src/ImplicitDifferentiation.jl
@@ -1,6 +1,6 @@
 module ImplicitDifferentiation
 
-using ChainRulesCore: ChainRulesCore, NoTangent, RuleConfig
+using ChainRulesCore: ChainRulesCore, NoTangent, RuleConfig, ZeroTangent
 using ChainRulesCore: frule_via_ad, rrule_via_ad, unthunk
 using Krylov: gmres
 using LinearOperators: LinearOperator


### PR DESCRIPTION
Simplify code by removing the `conditions_x` and `conditions_y` closures.
- For the forward pass, it should be strictly equivalent
- For the reverse pass, there might be slightly more work given that we compute 2 full pullbacks instead of one pullback for x and one for y. Not sure how it translates in terms of performance

At the moment, tests fail presumably due to https://github.com/ThummeTo/ForwardDiffChainRules.jl/issues/12