### PR TITLE
Add JET correctness testing and simplify pullbacks in rrule

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,8 +19,8 @@ jobs:
       matrix:
         version:
           - '1.7'
-          - '1'
-          - 'nightly'
+          - '1.8'
+          - '~1.9.0-0'
         os:
           - ubuntu-latest
         arch:

--- a/Project.toml
+++ b/Project.toml
@@ -33,6 +33,7 @@ LinearOperators = "5c8ed15e-5a4c-59e4-a42b-c7e8811fb125"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 MathOptSetDistances = "3b969827-a86c-476c-9527-bb6f1a8fbad5"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SCS = "c946c3f1-0d1f-5ce8-9dea-7daa1f7e2d13"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
@@ -40,4 +41,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Aqua", "ChainRulesCore", "ChainRulesTestUtils", "ComponentArrays", "Convex", "Distances", "Documenter", "FiniteDifferences", "ForwardDiff", "ForwardDiffChainRules", "JET", "JuliaFormatter", "LinearAlgebra", "LinearOperators", "MathOptInterface", "MathOptSetDistances", "Optim", "Random", "SCS", "SparseArrays", "Test", "Zygote"]
+test = ["Aqua", "ChainRulesCore", "ChainRulesTestUtils", "ComponentArrays", "Convex", "Distances", "Documenter", "FiniteDifferences", "ForwardDiff", "ForwardDiffChainRules", "JET", "JuliaFormatter", "LinearAlgebra", "LinearOperators", "MathOptInterface", "MathOptSetDistances", "Optim", "Pkg", "Random", "SCS", "SparseArrays", "Test", "Zygote"]

--- a/Project.toml
+++ b/Project.toml
@@ -25,6 +25,7 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 ForwardDiffChainRules = "c9556dd2-1aed-4cfe-8560-1557cf593001"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 Krylov = "ba0b0d4f-ebba-5204-a429-3ac8c609bfb7"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -39,4 +40,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Aqua", "ChainRulesCore", "ChainRulesTestUtils", "ComponentArrays", "Convex", "Distances", "Documenter", "FiniteDifferences", "ForwardDiff", "ForwardDiffChainRules", "JuliaFormatter", "LinearAlgebra", "LinearOperators", "MathOptInterface", "MathOptSetDistances", "Optim", "Random", "SCS", "SparseArrays", "Test", "Zygote"]
+test = ["Aqua", "ChainRulesCore", "ChainRulesTestUtils", "ComponentArrays", "Convex", "Distances", "Documenter", "FiniteDifferences", "ForwardDiff", "ForwardDiffChainRules", "JET", "JuliaFormatter", "LinearAlgebra", "LinearOperators", "MathOptInterface", "MathOptSetDistances", "Optim", "Random", "SCS", "SparseArrays", "Test", "Zygote"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,7 +26,7 @@ DocMeta.setdocmeta!(
     end
     @testset verbose = true "Code correctness (JET.jl)" begin
         if VERSION >= v"1.8"
-            JET.test_package(ImplicitDifferentiation; toplevel_logger=nothing)
+            @test_broken JET.test_package(ImplicitDifferentiation; toplevel_logger=nothing)
         end
     end
     @testset verbose = true "Doctests (Documenter.jl)" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,10 +2,13 @@
 
 using Aqua
 using Documenter
+using ForwardDiffChainRules
 using ImplicitDifferentiation
+using JET
 using JuliaFormatter
 using Random
 using Test
+using Zygote
 
 DocMeta.setdocmeta!(
     ImplicitDifferentiation, :DocTestSetup, :(using ImplicitDifferentiation); recursive=true
@@ -19,6 +22,9 @@ DocMeta.setdocmeta!(
     end
     @testset verbose = true "Code formatting (JuliaFormatter.jl)" begin
         @test format(ImplicitDifferentiation; verbose=true, overwrite=false)
+    end
+    @testset verbose = true "Code correctness (JET.jl)" begin
+        JET.test_package("ImplicitDifferentiation"; toplevel_logger=nothing)
     end
     @testset verbose = true "Doctests (Documenter.jl)" begin
         doctest(ImplicitDifferentiation)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ using ForwardDiffChainRules
 using ImplicitDifferentiation
 using JET
 using JuliaFormatter
+using Pkg
 using Random
 using Test
 using Zygote
@@ -13,6 +14,12 @@ using Zygote
 DocMeta.setdocmeta!(
     ImplicitDifferentiation, :DocTestSetup, :(using ImplicitDifferentiation); recursive=true
 )
+
+function get_pkg_version(name::AbstractString)
+    deps = Pkg.dependencies()
+    p = only(x for x in values(deps) if x.name == name)
+    return p.version
+end
 
 ## Test sets
 
@@ -24,7 +31,11 @@ DocMeta.setdocmeta!(
         @test format(ImplicitDifferentiation; verbose=true, overwrite=false)
     end
     @testset verbose = true "Code correctness (JET.jl)" begin
-        JET.test_package("ImplicitDifferentiation"; toplevel_logger=nothing)
+        if get_pkg_version("JET") >= v"0.7.11"
+            JET.test_package("InferOpt"; toplevel_logger=nothing)
+        else
+            @test string(JET.report_package(InferOpt)) == "No errors detected\n"
+        end
     end
     @testset verbose = true "Doctests (Documenter.jl)" begin
         doctest(ImplicitDifferentiation)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,7 +26,7 @@ DocMeta.setdocmeta!(
     end
     @testset verbose = true "Code correctness (JET.jl)" begin
         if VERSION >= v"1.8"
-            @test_broken JET.test_package(ImplicitDifferentiation; toplevel_logger=nothing)
+            JET.test_package(ImplicitDifferentiation; toplevel_logger=nothing)
         end
     end
     @testset verbose = true "Doctests (Documenter.jl)" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,12 +15,6 @@ DocMeta.setdocmeta!(
     ImplicitDifferentiation, :DocTestSetup, :(using ImplicitDifferentiation); recursive=true
 )
 
-function get_pkg_version(name::AbstractString)
-    deps = Pkg.dependencies()
-    p = only(x for x in values(deps) if x.name == name)
-    return p.version
-end
-
 ## Test sets
 
 @testset verbose = true "ImplicitDifferentiation.jl" begin
@@ -31,10 +25,8 @@ end
         @test format(ImplicitDifferentiation; verbose=true, overwrite=false)
     end
     @testset verbose = true "Code correctness (JET.jl)" begin
-        if get_pkg_version("JET") >= v"0.7.11"
-            JET.test_package("InferOpt"; toplevel_logger=nothing)
-        else
-            @test string(JET.report_package(InferOpt)) == "No errors detected\n"
+        if VERSION >= v"1.8"
+            JET.test_package(ImplicitDifferentiation; toplevel_logger=nothing)
         end
     end
     @testset verbose = true "Doctests (Documenter.jl)" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,7 +26,11 @@ DocMeta.setdocmeta!(
     end
     @testset verbose = true "Code correctness (JET.jl)" begin
         if VERSION >= v"1.8"
-            JET.test_package(ImplicitDifferentiation; toplevel_logger=nothing)
+            JET.test_package(
+                ImplicitDifferentiation;
+                toplevel_logger=nothing,
+                ignored_modules=(ForwardDiffChainRules,),  # TODO: remove once typo fixed
+            )
         end
     end
     @testset verbose = true "Doctests (Documenter.jl)" begin


### PR DESCRIPTION
Changes:
- Check static correctness of the whole package with JET.jl
- Replace two pullbacks with one in `rrule`
- Switch signs in linear system for better readability

At the moment, the tests:
- pass on 1.7 because `JET.test_package` doesn't exist for it
- would fail on 1.8 and 1.9 because of a typo in ForwardDiffChainRules (https://github.com/ThummeTo/ForwardDiffChainRules.jl/pull/13), which is why I ignored this module temporarily
- might fail on 1.10 because of a bug in Zygote (https://github.com/FluxML/Zygote.jl/issues/1410)