### PR TITLE
Performance tweaks

### DIFF
--- a/ext/ImplicitDifferentiationChainRulesExt.jl
+++ b/ext/ImplicitDifferentiationChainRulesExt.jl
@@ -51,7 +51,8 @@ function (implicit_pullback::ImplicitPullback)((dy, dz))
     dy_vec = convert(Vector{R}, vec(unthunk(dy)))
     dF_vec, stats = linear_solver(Aᵀ_op, dy_vec)
     check_solution(linear_solver, stats)
-    dx_vec = -(Bᵀ_op * dF_vec)
+    dx_vec = Bᵀ_op * dF_vec
+    dx_vec .*= -1
     dx = reshape(dx_vec, size(x))
     return (NoTangent(), dx)
 end

--- a/ext/ImplicitDifferentiationForwardDiffExt.jl
+++ b/ext/ImplicitDifferentiationForwardDiffExt.jl
@@ -33,7 +33,8 @@ function (implicit::ImplicitFunction)(
 
     dy = map(1:N) do k
         dₖx_vec = vec(partials.(x_and_dx, k))
-        dₖy_vec, stats = linear_solver(A_op, -(B_op * dₖx_vec))
+        dₖy_vec, stats = linear_solver(A_op, B_op * dₖx_vec)
+        dₖy_vec .*= -1
         check_solution(linear_solver, stats)
         reshape(dₖy_vec, size(y))
     end

--- a/src/ImplicitDifferentiation.jl
+++ b/src/ImplicitDifferentiation.jl
@@ -2,7 +2,7 @@ module ImplicitDifferentiation
 
 using AbstractDifferentiation: LazyJacobian, ReverseRuleConfigBackend, lazy_jacobian
 using Krylov: KrylovStats, gmres
-using LinearOperators: LinearOperator
+using LinearOperators: LinearOperators, LinearOperator
 using Requires: @require
 
 include("utils.jl")

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -57,3 +57,8 @@ function (pbm::PullbackMul!)(res::AbstractVector, δoutput_vec::AbstractVector)
     δinput = only(pbm.pullback(δoutput))
     return res .= vec(δinput)
 end
+
+## Override this function from LinearOperators to avoid generating the whole methods table
+
+LinearOperators.get_nargs(pfm::PushforwardMul!) = 1
+LinearOperators.get_nargs(pbm::PullbackMul!) = 1


### PR DESCRIPTION
- Override `LinearOperators.get_nargs` to avoid building a whole methods table (this allocates, which affects benchmarks in low-dimensional problems)
- Remove one allocation when computing `-d` (first compute `d` and then multiply by `-1` in-place)