### PR TITLE
Don't dualize `z`

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -2,7 +2,7 @@
 	author  = {Guillaume Dalle, Mohamed Tarek and contributors},
 	title   = {ImplicitDifferentiation.jl},
 	url     = {https://github.com/gdalle/ImplicitDifferentiation.jl},
-	version = {v0.4.2},
+	version = {v0.4.3},
 	year    = {2023},
 	month   = {5}
 }

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ImplicitDifferentiation"
 uuid = "57b37032-215b-411a-8a7c-41a003a55207"
 authors = ["Guillaume Dalle", "Mohamed Tarek and contributors"]
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 AbstractDifferentiation = "c29ec348-61ec-40c8-8164-b8c60e9d9f3d"

--- a/ext/ImplicitDifferentiationForwardDiffExt.jl
+++ b/ext/ImplicitDifferentiationForwardDiffExt.jl
@@ -44,12 +44,7 @@ function (implicit::ImplicitFunction)(
             Dual{T}(y[i], Partials(ntuple(k -> dy[k][i], Val(N))))
         end
     end
-
-    z_and_dz = let z = z
-        Dual{T}(z, Partials(ntuple(_ -> zero(z), Val(N))))
-    end
-
-    return y_and_dy, z_and_dz
+    return y_and_dy, z
 end
 
 end

--- a/src/implicit_function.jl
+++ b/src/implicit_function.jl
@@ -3,7 +3,7 @@
 
 Differentiable wrapper for an implicit function `x -> y(x)` whose output is defined by conditions `F(x,y(x)) = 0`.
 
-More generally, we consider functions `x -> (y(x),z(x))` and conditions `F(x,y(x),z(x)) = 0`, where `z(x)` contains additional information that _is considered constant for differentiation purposes_. Beware: the method `zero(z)` must exist.
+More generally, we consider functions `x -> (y(x),z(x))` and conditions `F(x,y(x),z(x)) = 0`, where `z(x)` contains additional information that _is considered constant for differentiation purposes_.
 
 If `x ∈ ℝⁿ` and `y ∈ ℝᵈ`, then we need as many conditions as output dimensions: `F(x,y,z) ∈ ℝᵈ`. Thanks to these conditions, we can compute the Jacobian of `y(⋅)` using the implicit function theorem:
 ```


### PR DESCRIPTION
I'm not sure why `z` was dualized, the partials were all set to zero anyway. The implementation had several problems, and errored if `z` was an array or any other object.