### PR TITLE
Remove `<:Real` constraint in rrule

### DIFF
--- a/ext/ImplicitDifferentiationChainRulesExt.jl
+++ b/ext/ImplicitDifferentiationChainRulesExt.jl
@@ -15,7 +15,7 @@ Keyword arguments are given to both `implicit.forward` and `implicit.conditions`
 """
 function ChainRulesCore.rrule(
     rc::RuleConfig, implicit::ImplicitFunction, x::AbstractArray{R}; kwargs...
-) where {R<:Real}
+) where {R}
     conditions = implicit.conditions
     linear_solver = implicit.linear_solver
 


### PR DESCRIPTION
Arbitrary number types are now accepted

@baggepinnen is this what you were mentioning in #43 ?