### PR TITLE
NaNs for linear solvers when failed

### DIFF
--- a/ext/ImplicitDifferentiationStaticArraysExt.jl
+++ b/ext/ImplicitDifferentiationStaticArraysExt.jl
@@ -6,16 +6,15 @@ else
     using ..StaticArrays: StaticArray, MMatrix
 end
 
-import ImplicitDifferentiation: ImplicitDifferentiation, DirectLinearSolver
+import ImplicitDifferentiation: ImplicitDifferentiation, DirectLinearSolver, solve
 using LinearAlgebra: lu, mul!
 
-function ImplicitDifferentiation.presolve(
-    ::DirectLinearSolver, A, y::StaticArray{S,T,N}
-) where {S,T,N}
+function ImplicitDifferentiation.presolve(::DirectLinearSolver, A, y::StaticArray)
+    T = eltype(A)
     m = length(y)
     A_static = zero(MMatrix{m,m,T})
+    v = vec(similar(y, T))
     for i in axes(A_static, 2)
-        v = vec(similar(y))
         v .= zero(T)
         v[i] = one(T)
         mul!(@view(A_static[:, i]), A, v)

--- a/src/ImplicitDifferentiation.jl
+++ b/src/ImplicitDifferentiation.jl
@@ -2,7 +2,7 @@ module ImplicitDifferentiation
 
 using Krylov: KrylovStats, gmres
 using LinearOperators: LinearOperators, LinearOperator
-using LinearAlgebra: lu, SingularException
+using LinearAlgebra: lu, SingularException, issuccess
 using Requires: @require
 using SimpleUnPack: @unpack
 

--- a/src/linear_solver.jl
+++ b/src/linear_solver.jl
@@ -3,10 +3,13 @@
 
 All linear solvers used within an `ImplicitFunction` must satisfy this interface.
 
+It can be useful to roll out your own solver if you need more fine-grained control on convergence / speed / behavior in case of singularity.
+Check out the source code of `IterativeLinearSolver` and `DirectLinearSolver` for implementation examples. 
+
 # Required methods
 
-- `presolve(linear_solver, A, y)`: return a matrix-like object `A` for which it is cheaper to solve several linear systems with different vectors `b` (a typical example would be to perform LU factorization).
-- `solve(linear_solver, A, b)`: return a tuple `(x, stats)` where `x` satisfies `Ax = b` and `stats.solved ∈ {true, false}`.
+- `presolve(linear_solver, A, y)`: Returns a matrix-like object `A` for which it is cheaper to solve several linear systems with different vectors `b` (a typical example would be to perform LU factorization).
+- `solve(linear_solver, A, b)`: Returns a vector `x` satisfying `Ax = b`. If the linear system has not been solved to satisfaction, every element of `x` should be a `NaN` of the appropriate floating point type.
 """
 abstract type AbstractLinearSolver end
 
@@ -20,11 +23,15 @@ struct IterativeLinearSolver <: AbstractLinearSolver end
 presolve(::IterativeLinearSolver, A, y) = A
 
 function solve(::IterativeLinearSolver, A, b)
+    T = float(promote_type(eltype(A), eltype(b)))
     x, stats = gmres(A, b)
-    if !stats.solved
-        throw(SolverFailureException(gmres, stats))
+    x_maybenan = similar(x, T)
+    if stats.solved && !stats.inconsistent
+        x_maybenan .= x
+    else
+        x_maybenan .= convert(T, NaN)
     end
-    return x
+    return x_maybenan
 end
 
 """
@@ -34,17 +41,18 @@ An implementation of `AbstractLinearSolver` using the built-in backslash operato
 """
 struct DirectLinearSolver <: AbstractLinearSolver end
 
-presolve(::DirectLinearSolver, A, y) = lu(Matrix(A))
-solve(::DirectLinearSolver, A, b) = A \ b
-
-struct SolverFailureException{A,B} <: Exception
-    solver::A
-    stats::B
+function presolve(::DirectLinearSolver, A, y)
+    return lu(Matrix(A); check=false)
 end
 
-function Base.show(io::IO, sfe::SolverFailureException)
-    return println(
-        io,
-        "SolverFailureException: \n Linear solver: $(sfe.solver) \n Solver stats: $(string(sfe.stats))",
-    )
+function solve(::DirectLinearSolver, A_lu, b)
+    # workaround for https://github.com/JuliaArrays/StaticArrays.jl/issues/1190
+    T = float(promote_type(eltype(A_lu.L), eltype(A_lu.U), eltype(b)))
+    x_maybenan = Vector{T}(undef, size(A_lu.L, 2))
+    if issuccess(A_lu)
+        x_maybenan .= A_lu \ b
+    else
+        x_maybenan .= convert(T, NaN)
+    end
+    return x_maybenan
 end

--- a/test/errors.jl
+++ b/test/errors.jl
@@ -1,0 +1,54 @@
+using ForwardDiff
+using ImplicitDifferentiation
+using Test
+using Zygote
+
+@testset "Byproduct handling" begin
+    f = (_) -> [1.0, 2.0]
+    c = (_, _) -> [0.0, 0.0]
+    imf1 = ImplicitFunction(f, c, HandleByproduct())
+    @test_throws ArgumentError imf1(zeros(2))
+    f = (_) -> [1.0, 2.0, 3.0]
+    imf2 = ImplicitFunction(f, c, HandleByproduct())
+    @test_throws ArgumentError imf2(zeros(2))
+end
+
+@testset "Only accept one array" begin
+    f = (_) -> [1.0]
+    c = (_, _) -> [0.0]
+    imf = ImplicitFunction(f, c)
+    @test_throws MethodError imf("hello")
+    @test_throws MethodError imf([1.0], [1.0])
+end
+
+@testset verbose = true "Derivative NaNs" begin
+    x = zeros(Float32, 2)
+    linear_solvers = (IterativeLinearSolver(), DirectLinearSolver())
+    @testset "Infinite derivative" begin
+        f = x -> sqrt.(x)  # nondifferentiable at 0
+        c = (x, y) -> y .^ 2 .- x
+        for linear_solver in linear_solvers
+            @testset "$(typeof(linear_solver))" begin
+                implicit = ImplicitFunction(f, c; linear_solver)
+                J1 = ForwardDiff.jacobian(implicit, x)
+                J2 = Zygote.jacobian(implicit, x)[1]
+                @test all(isnan, J1) && eltype(J1) == Float32
+                @test all(isnan, J2) && eltype(J2) == Float32
+            end
+        end
+    end
+
+    @testset "Singular linear system" begin
+        f = x -> x  # wrong solver
+        c = (x, y) -> (x .+ 1) .^ 2 .- y .^ 2
+        for linear_solver in linear_solvers
+            @testset "$(typeof(linear_solver))" begin
+                implicit = ImplicitFunction(f, c; linear_solver)
+                J1 = ForwardDiff.jacobian(implicit, x)
+                J2 = Zygote.jacobian(implicit, x)[1]
+                @test all(isnan, J1) && eltype(J1) == Float32
+                @test all(isnan, J2) && eltype(J2) == Float32
+            end
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,6 +65,9 @@ EXAMPLES_DIR_JL = joinpath(dirname(@__DIR__), "examples")
     @testset verbose = true "Systematic" begin
         include("systematic.jl")
     end
+    @testset verbose = true "Errors" begin
+        include("errors.jl")
+    end
     @testset verbose = true "Examples" begin
         for file in readdir(EXAMPLES_DIR_JL)
             path = joinpath(EXAMPLES_DIR_JL, file)


### PR DESCRIPTION
Instead of throwing an error, return a useless solution full of `NaN`s if a certain condition is not  met:
* For the iterative solver, check whether the system is consistent and whether the algorithm converged
* For the direct solver with LU presolve, check whether the factorization was a success

I now preallocate the output of `A \ b` for type stability reasons (otherwise `return cond ? x : fill(NaN, n)` would be type-unstable).
In the worst case this doubles the allocations
