### PR TITLE
Supplement documentation to `DirectLinearSolver`

### DIFF
--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -105,12 +105,12 @@ using Memoize
 
 ### Linear solver selection
 
-Differentiating your implicit function requires to solve a linear system. By default, an iterative solver (see [`IterativeSolver`](@ref)) combined with a matrix-free representation of the jacobian (see [`OperatorRepresentation`](@ref)) is used. You can change the linear solver using the `linear_solver` keyword argument of the `ImplicitFunction` constructor, choosing between:
+Differentiating your implicit function requires to solve a linear system. By default, an iterative solver (see [`IterativeLinearSolver`](@ref)) combined with a matrix-free representation of the jacobian (see [`OperatorRepresentation`](@ref)) is used. You can change the linear solver using the `linear_solver` keyword argument of the `ImplicitFunction` constructor, choosing between:
 
-- [`IterativeSolver`](@ref);
+- [`IterativeLinearSolver`](@ref);
 - [`IterativeLeastSquaresSolver`](@ref);
 - [`DirectLinearSolver`](@ref).
 
-Keyword arguments can be passed to the constructors of `IterativeSolver` and `IterativeLeastSquaresSolver`, they will be forwarded to the `KrylovKit.linsolve` and `KrylovKit.lssolve` functions, respectively.
+Keyword arguments can be passed to the constructors of `IterativeLinearSolver` and `IterativeLeastSquaresSolver`, they will be forwarded to the `KrylovKit.linsolve` and `KrylovKit.lssolve` functions, respectively.
 
 Note that for the `DirectLinearSolver`, you must switch to a [`MatrixRepresentation`](@ref) using the `representation` argument : `ImplicitFunction(forward, conditions; linear_solver = DirectLinearSolver(), representation = MatrixRepresentation())`.

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -111,6 +111,9 @@ Differentiating your implicit function requires to solve a linear system. By def
 - [`IterativeLeastSquaresSolver`](@ref);
 - [`DirectLinearSolver`](@ref).
 
-Keyword arguments can be passed to the constructors of `IterativeLinearSolver` and `IterativeLeastSquaresSolver`, they will be forwarded to the `KrylovKit.linsolve` and `KrylovKit.lssolve` functions, respectively.
+Keyword arguments can be passed to the constructors of `IterativeLinearSolver` and `IterativeLeastSquaresSolver`, they will be forwarded to the solver that is currently being used.
+
+!!! warning
+    The specific choice of solver is not part of the public API, and may thus change without a breaking release. If you rely on keyword arguments, please freeze the exact version of ImplicitDifferentiation in your `Project.toml`.
 
 Note that for the `DirectLinearSolver`, you must switch to a [`MatrixRepresentation`](@ref) using the `representation` argument : `ImplicitFunction(forward, conditions; linear_solver = DirectLinearSolver(), representation = MatrixRepresentation())`.

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -102,3 +102,15 @@ Packages such as [Memoize.jl](https://github.com/JuliaCollections/Memoize.jl) an
 using Memoize
 @memoize Dict forward(x, args...; kwargs...) = y, z
 ```
+
+### Linear solver selection
+
+Differentiating your implicit function requires to solve a linear system. By default, an iterative solver (see [`IterativeSolver`](@ref)) combined with a matrix-free representation of the jacobian (see [`OperatorRepresentation`](@ref)) is used. You can change the linear solver using the `linear_solver` keyword argument of the `ImplicitFunction` constructor, choosing between:
+
+- [`IterativeSolver`](@ref);
+- [`IterativeLeastSquaresSolver`](@ref);
+- [`DirectLinearSolver`](@ref).
+
+Keyword arguments can be passed to the constructors of `IterativeSolver` and `IterativeLeastSquaresSolver`, they will be forwarded to the `KrylovKit.linsolve` and `KrylovKit.lssolve` functions, respectively.
+
+Note that for the `DirectLinearSolver`, you must switch to a [`MatrixRepresentation`](@ref) using the `representation` argument : `ImplicitFunction(forward, conditions; linear_solver = DirectLinearSolver(), representation = MatrixRepresentation())`.

--- a/src/settings.jl
+++ b/src/settings.jl
@@ -10,7 +10,7 @@ Specify that linear systems `Ax = b` should be solved with a direct method.
 !!! warning
     Can only be used when the `solver` and the `conditions` both output an `AbstractVector`.
 
-    Additionnaly, this solver requires a [`MatrixRepresentation`](@ref) of the matrix `A`. To do so,
+    Additionally, this solver requires a [`MatrixRepresentation`](@ref) of the matrix `A`. To do so,
     use the `representation` keyword of the [`ImplicitFunction`](@ref) constructor :
 
         f = ImplicitFunction(

--- a/src/settings.jl
+++ b/src/settings.jl
@@ -12,14 +12,13 @@ Specify that linear systems `Ax = b` should be solved with a direct method.
 
     Additionnaly, this solver requires a [`MatrixRepresentation`](@ref) of the matrix `A`. To do so,
     use the `representation` keyword of the [`ImplicitFunction`](@ref) constructor :
-    ```
-    f = ImplicitFunction(
-        forward,
-        conditions;
-        solver = DirectLinearSolver(),
-        representation = MatrixRepresentation()
-    )
-    ```
+
+        f = ImplicitFunction(
+            forward,
+            conditions;
+            solver = DirectLinearSolver(),
+            representation = MatrixRepresentation()
+        )
 
 # See also
 

--- a/src/settings.jl
+++ b/src/settings.jl
@@ -10,6 +10,17 @@ Specify that linear systems `Ax = b` should be solved with a direct method.
 !!! warning
     Can only be used when the `solver` and the `conditions` both output an `AbstractVector`.
 
+    Additionnaly, this solver requires a [`MatrixRepresentation`](@ref) of the matrix `A`. To do so,
+    use the `representation` keyword of the [`ImplicitFunction`](@ref) constructor :
+    ```
+    f = ImplicitFunction(
+        forward,
+        conditions;
+        solver = DirectLinearSolver(),
+        representation = MatrixRepresentation()
+    )
+    ```
+
 # See also
 
 - [`ImplicitFunction`](@ref)


### PR DESCRIPTION
This is a proposal to specify how to select the `DirectLinearSolver`, i.e : "use the `MatrixRepresentation`". This is an answer to #189 .

I don't know why, but I failed to compile the documentation locally, at least the `settings.jl` part. Before activating the github build action, maybe you can just take a look at the modifications and give me some feedback?